### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
+  - "node"
+  - "10"
   - "8"
   - "6"
-  - "4"
 after_success: npm run coverage
+install: npm install


### PR DESCRIPTION
We should only test the current active LTS and stable branches. Stable (11) because we want to fail early and `npm install` as lockfiles are ignored on the consumer side (npmjs).