### PR TITLE
Remove incomplete module entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
 	"version": "2.6.0",
 	"description": "Compress JSON into compact base64 URI-friendly notation",
 	"main": "dist/node/index.js",
-	"module": "src/main/index.js",
 	"browser": "dist/browser/json-url-single.js",
 	"scripts": {
 		"lint": "eslint src/*",


### PR DESCRIPTION
This should fix masotime/json-url#17

Currently, when some bundlers import json-url, they see the module entrypoint and favor it over the commonjs, node, or browser entrypoints.

Unfortunately, the module entrypoint won't work successfully until can we use a bundling tool that creates a ESM-friendly bundle ([Webpack still can't do that](https://github.com/webpack/webpack/issues/2933#issuecomment-652942095)). This is because json-url has dependencies that aren't ESM friendly.

It seems like the best thing to do is to back out this change for now.